### PR TITLE
Fix PHP error breaking admin area

### DIFF
--- a/src/LPTS.php
+++ b/src/LPTS.php
@@ -24,9 +24,6 @@ final class LPTS
 
     public function __construct()
     {
-        $this->request_uri = $_SERVER['REQUEST_URI'];
-        $this->array = explode('/', $this->request_uri);
-
         add_action('init', [$this, 'load']);
 
         add_action('admin_enqueue_scripts', [$this, 'enqueueStyles']);
@@ -76,7 +73,7 @@ final class LPTS
      */
     public function enqueueStyles()
     {
-        if (strpos($this->array[3], 'link_products_to_sendinblue')) {
+        if (isset($_GET['page']) && $_GET['page'] === 'link_products_to_sendinblue') {
             wp_enqueue_style(
                 'lpts_bootstrap',
                 LPTS_URL . 'assets/vendor/bootstrap/css/bootstrap.min.css',
@@ -102,7 +99,7 @@ final class LPTS
      */
     public function enqueueScripts()
     {
-        if (strpos($this->array[3], 'link_products_to_sendinblue')) {
+        if (isset($_GET['page']) && $_GET['page'] === 'link_products_to_sendinblue') {
             wp_enqueue_script(
                 'link_products_to_sendinblue',
                 LPTS_URL . 'assets/js/app.js',

--- a/src/LPTS.php
+++ b/src/LPTS.php
@@ -61,7 +61,7 @@ final class LPTS
             load_plugin_textdomain(
                 LPTS_TEXT_DOMAIN,
                 false,
-                LPTS_PATH . 'langages'
+                LPTS_PATH . 'languages'
             );
         });
     }
@@ -93,7 +93,7 @@ final class LPTS
     }
 
     /**
-     * Load plugin scipt
+     * Load plugin script
      *
      * @since 1.0.0
      */


### PR DESCRIPTION
As mentioned in #1 this plugin throws an error which prevents the requires assets from being enqueued for the admin UI, as mentioned in #2.

The error is caused by `$this->array[3]` not always being available. Looks like this is only used for the `page` query parameter. Fetching this in a different way solves the issue.

**Screenshots:**

**Before:**
![image](https://user-images.githubusercontent.com/247634/179053749-85fb0a2f-e6da-4e9f-8273-f279e2cfec3c.png)

**After:**
![image](https://user-images.githubusercontent.com/247634/179053673-7c0e7ca8-bc02-4e02-8adb-9f8b812444bb.png)

---

closes #1
closes #2