### PR TITLE
Update plugin "Tested up to"

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: mzeahmed
 Tags: woocommerce, sendinblue
 Requires at last: 5.1
-Tested up to: 5.8.2
+Tested up to: 6.0
 Stable tag: 1.1.4.2
 Requires PHP: 7.4
 License: GPLv2 or later


### PR DESCRIPTION
Have been running this on WordPress 6.0, here's an update to the `Tested up to`.